### PR TITLE
fixes #15 - keyboard accident

### DIFF
--- a/Commands/notify.py
+++ b/Commands/notify.py
@@ -215,7 +215,7 @@ class Notify(commands.Cog, name="Notification_lists"):
                             + ctx.bot.get_emoji(reaction_emoji).name
                             + ":"
                             + str(reaction_emoji)
-                            + ">"s
+                            + ">"
                         )
                         custom_emoji = True
                     except AttributeError:


### PR DESCRIPTION
**Make sure every command has the help text set up as explained in [the wiki](https://github.com/nerdland-unofficial-fans/nerdlandbot/wiki/Command-help)**
