### PR TITLE
makes notify more robust for long messages

### DIFF
--- a/Commands/notify.py
+++ b/Commands/notify.py
@@ -104,6 +104,9 @@ class Notify(commands.Cog, name="Notification_lists"):
             msg = translate("list_err_empty", await culture(ctx))
             return await ctx.send(msg)
 
+        # Setup the announcement with the subject and caller
+        message_text = translate("notifying", await culture(ctx)).format(list_name.capitalize(), ctx.message.author.id, ctx.guild.get_member(ctx.bot.user.id).display_name)
+
         # build users mentioning string
         user_tags = []
         for user_id in users:
@@ -111,15 +114,18 @@ class Notify(commands.Cog, name="Notification_lists"):
 
         users_str = ', '.join(user_tags)
 
-        # Setup the announcement with the subject and caller
-        message_text = translate("notifying", await culture(ctx)).format(list_name.capitalize(), ctx.message.author.id, ctx.guild.get_member(ctx.bot.user.id).display_name)
-
         # append the message if provided
         if message:
+            # If message too long, tell user to write shorter message
+            excess = -1999 + len(message) + len(message_text)
+            if excess > 0:
+                msg = translate("notif_too_long", await culture(ctx)).format(excess)
+                return await ctx.send(msg)
             second_line = translate("notify_message", await culture(ctx)).format(message) + '\n'
             message_text += second_line
 
-        await ctx.send(message_text + '\n' + users_str)
+        await ctx.send(message_text)
+        await ctx.send(users_str)
 
     async def wait_for_added_reactions(self, ctx: commands.Context, msg_id: int, guild_data: GuildData,
                                        timeout: int = 300):

--- a/Translations/Translations.csv
+++ b/Translations/Translations.csv
@@ -92,3 +92,4 @@
 "picked_new_language","The new language is: {0}.","De nieuwe taal is: {0}."
 "nl","Dutch","Nederlands"
 "en","English","Engels"
+"notif_too_long","Your message is {0} characters too long for the Discord bot","Je bericht is {0} tekens te lang, probeer met een korter bericht."


### PR DESCRIPTION
Fixes an issue where currently messages with too long a text result in notify not working.

Splits the message in two: one for the message and one for the user list. Checks that the message provided by user will fit in the total allowed by discord (including the prefix coming from translate), if not will tell user to send shorter message.
