### PR TITLE
removes possibility of subbing and unsubbing other users

### DIFF
--- a/nerdlandbot/commands/notify.py
+++ b/nerdlandbot/commands/notify.py
@@ -16,7 +16,7 @@ class Notify(commands.Cog, name="Notification_lists"):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    async def act_subscribe(self,ctx: commands.Context,list_name: str,user_id: int):
+    async def act_subscribe(self, ctx: commands.Context, list_name: str, user_id: int):
         """
         Subscribes user to a list and confirms with message
         :param ctx: The current context. (discord.ext.commands.Context)
@@ -42,7 +42,7 @@ class Notify(commands.Cog, name="Notification_lists"):
         msg = translate("list_subscribed", await culture(ctx)).format(str(user_id), list_name)
         await ctx.send(msg)
 
-    async def act_unsubscribe(self,ctx: commands.Context, list_name: str, user_id: int):
+    async def act_unsubscribe(self, ctx: commands.Context, list_name: str, user_id: int):
         """
         Unsubscribes the user from the provided list
         :param ctx: The current context. (discord.ext.commands.Context)
@@ -185,7 +185,7 @@ class Notify(commands.Cog, name="Notification_lists"):
                 for key, v in guild_data.notification_lists.items():
                     if reaction_emoji == v["emoji"]:
                         list_name = key
-                        await self.act_subscribe(ctx, list_name,user.id,)
+                        await self.act_subscribe(ctx, list_name,user.id)
 
             except asyncio.TimeoutError:
                 pass

--- a/nerdlandbot/commands/notify.py
+++ b/nerdlandbot/commands/notify.py
@@ -16,23 +16,13 @@ class Notify(commands.Cog, name="Notification_lists"):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @commands.command(name="sub", aliases=["subscribe"], brief="notify_sub_brief", usage="notify_sub_usage",
-                      help="notify_sub_help")
-    async def subscribe(self, ctx: commands.Context, list_name: typing.Optional[str] = None, user_id=None, is_reaction=False):
+    async def act_subscribe(self,ctx: commands.Context,list_name: str,user_id: int):
         """
-        If used with list_name, subscribes the user to that list if possible.
-        If used without parameter it prints the existing lists, and allows users to subscribe by adding reactions.
-        :param ctx: The current context (discord.ext.commands.Context)
-        :param list_name: The list to subscribe to. (optional - str - default = None)
+        Subscribes user to a list and confirms with message
+        :param ctx: The current context. (discord.ext.commands.Context)
+        :param list_name: The list to subscribe to. (str)
+        :param user_id: the user to subscribe (int)
         """
-
-        if not is_reaction:
-            user_id = ctx.author.id
-
-        # Execute 'show_lists' if no parameter provided
-        if not list_name:
-            return await self.show_lists(ctx)
-
         # Make sure list is lowercase
         list_name = list_name.lower()
 
@@ -52,17 +42,13 @@ class Notify(commands.Cog, name="Notification_lists"):
         msg = translate("list_subscribed", await culture(ctx)).format(str(user_id), list_name)
         await ctx.send(msg)
 
-    @commands.command(name="unsub", aliases=["unsubscribe"], brief="notify_unsub_brief", usage="notify_unsub_usage",
-                      help="notify_unsub_help")
-    async def unsubscribe(self, ctx: commands.Context, list_name: str, user_id=None, is_reaction=False):
+    async def act_unsubscribe(self,ctx: commands.Context, list_name: str, user_id: int):
         """
         Unsubscribes the user from the provided list
         :param ctx: The current context. (discord.ext.commands.Context)
         :param list_name: The list to unsubscribe from. (str)
+        :param user_id: the user to unsubscribe (int)
         """
-        if not is_reaction:
-            user_id = ctx.author.id
-
         # make sure list is lowercase
         list_name = list_name.lower()
 
@@ -81,6 +67,33 @@ class Notify(commands.Cog, name="Notification_lists"):
         # Unsubscribe successful, show result to user
         msg = translate("list_unsubscribed", await culture(ctx)).format(str(user_id), list_name)
         await ctx.send(msg)
+
+    @commands.command(name="sub", aliases=["subscribe"], brief="notify_sub_brief", usage="notify_sub_usage",
+                      help="notify_sub_help")
+    async def subscribe(self, ctx: commands.Context, list_name: typing.Optional[str] = None):
+        """
+        If used with list_name, subscribes the user to that list if possible.
+        If used without parameter it prints the existing lists, and allows users to subscribe by adding reactions.
+        :param ctx: The current context (discord.ext.commands.Context)
+        :param list_name: The list to subscribe to. (optional - str - default = None)
+        """
+
+        # Execute 'show_lists' if no parameter provided
+        if not list_name:
+            return await self.show_lists(ctx)
+        
+        #handle subscribe
+        await self.act_subscribe(ctx, list_name, ctx.author.id)
+
+    @commands.command(name="unsub", aliases=["unsubscribe"], brief="notify_unsub_brief", usage="notify_unsub_usage",
+                      help="notify_unsub_help")
+    async def unsubscribe(self, ctx: commands.Context, list_name: str):
+        """
+        Command to unsubscribe, calls act_unsibscribe to make it happen
+        :param ctx: The current context. (discord.ext.commands.Context)
+        :param list_name: The list to unsubscribe from. (str)
+        """
+        await self.act_unsubscribe(ctx,list_name,ctx.author.id)
 
     @commands.command(name="notify", usage="notify_notify_usage", brief="notify_notify_brief", help="notify_notify_help")
     async def notify(self, ctx: commands.Context, list_name: str, *, message: typing.Optional[str] = None):
@@ -172,7 +185,7 @@ class Notify(commands.Cog, name="Notification_lists"):
                 for key, v in guild_data.notification_lists.items():
                     if reaction_emoji == v["emoji"]:
                         list_name = key
-                        await self.subscribe(ctx, list_name,user.id,True)
+                        await self.act_subscribe(ctx, list_name,user.id,)
 
             except asyncio.TimeoutError:
                 pass
@@ -205,7 +218,7 @@ class Notify(commands.Cog, name="Notification_lists"):
 
                     if reaction_emoji == v["emoji"]:
                         list_name = key
-                        await self.unsubscribe(ctx, list_name,user.id,True)
+                        await self.act_unsubscribe(ctx, list_name,user.id)
 
             except asyncio.TimeoutError:
                 pass

--- a/nerdlandbot/commands/notify.py
+++ b/nerdlandbot/commands/notify.py
@@ -18,7 +18,7 @@ class Notify(commands.Cog, name="Notification_lists"):
 
     @commands.command(name="sub", aliases=["subscribe"], brief="notify_sub_brief", usage="notify_sub_usage",
                       help="notify_sub_help")
-    async def subscribe(self, ctx: commands.Context, list_name: typing.Optional[str] = None, user_id=None):
+    async def subscribe(self, ctx: commands.Context, list_name: typing.Optional[str] = None, user_id=None, is_reaction=False):
         """
         If used with list_name, subscribes the user to that list if possible.
         If used without parameter it prints the existing lists, and allows users to subscribe by adding reactions.
@@ -26,7 +26,7 @@ class Notify(commands.Cog, name="Notification_lists"):
         :param list_name: The list to subscribe to. (optional - str - default = None)
         """
 
-        if not user_id:
+        if not user_id or not is_reaction:
             user_id = ctx.author.id
 
         # Execute 'show_lists' if no parameter provided
@@ -54,13 +54,13 @@ class Notify(commands.Cog, name="Notification_lists"):
 
     @commands.command(name="unsub", aliases=["unsubscribe"], brief="notify_unsub_brief", usage="notify_unsub_usage",
                       help="notify_unsub_help")
-    async def unsubscribe(self, ctx: commands.Context, list_name: str, user_id=None):
+    async def unsubscribe(self, ctx: commands.Context, list_name: str, user_id=None, is_reaction=False):
         """
         Unsubscribes the user from the provided list
         :param ctx: The current context. (discord.ext.commands.Context)
         :param list_name: The list to unsubscribe from. (str)
         """
-        if not user_id:
+        if not user_id or not is_reaction:
             user_id = ctx.author.id
 
         # make sure list is lowercase
@@ -172,7 +172,7 @@ class Notify(commands.Cog, name="Notification_lists"):
                 for key, v in guild_data.notification_lists.items():
                     if reaction_emoji == v["emoji"]:
                         list_name = key
-                        await self.subscribe(ctx, list_name,user.id)
+                        await self.subscribe(ctx, list_name,user.id,True)
 
             except asyncio.TimeoutError:
                 pass
@@ -205,7 +205,7 @@ class Notify(commands.Cog, name="Notification_lists"):
 
                     if reaction_emoji == v["emoji"]:
                         list_name = key
-                        await self.unsubscribe(ctx, list_name,user.id)
+                        await self.unsubscribe(ctx, list_name,user.id,True)
 
             except asyncio.TimeoutError:
                 pass

--- a/nerdlandbot/commands/notify.py
+++ b/nerdlandbot/commands/notify.py
@@ -26,7 +26,7 @@ class Notify(commands.Cog, name="Notification_lists"):
         :param list_name: The list to subscribe to. (optional - str - default = None)
         """
 
-        if not user_id or not is_reaction:
+        if not is_reaction:
             user_id = ctx.author.id
 
         # Execute 'show_lists' if no parameter provided
@@ -60,7 +60,7 @@ class Notify(commands.Cog, name="Notification_lists"):
         :param ctx: The current context. (discord.ext.commands.Context)
         :param list_name: The list to unsubscribe from. (str)
         """
-        if not user_id or not is_reaction:
+        if not is_reaction:
             user_id = ctx.author.id
 
         # make sure list is lowercase


### PR DESCRIPTION
Small alteration to code so that it prevents unwanted sub and unsub usage where users would provide a discord ID and make the command take effect on other users.