### PR TITLE
Avoid using litteral unicode characters, let's keep it simple

### DIFF
--- a/nerdlandbot/translations/Translations.csv
+++ b/nerdlandbot/translations/Translations.csv
@@ -127,4 +127,4 @@
 "purger_removed","No longer automatically removing messages in <#{0}>.","Berichten worden niet meer automatisch verwijderd in <#{0}>."
 "purger_no_exists","There's no automatic message removal in <#{0}>.","Er worden geen berichten verwijderd in <#{0}>."
 "purger_list_title","List of channels with automatic removal of messages and max age:","Lijst van kanalen waar berichten automatisch worden verwijderd en de maximale leeftijd:"
-"purger_list_item","  · <#{0}>: {1} day(s)","  · <#{0}>: {1} dag(en)"
+"purger_list_item","  - <#{0}>: {1} day(s)","  - <#{0}>: {1} dag(en)"


### PR DESCRIPTION
The · character was causing a Â character to be printed in front of it. Simple solution, just use a -
