### PR TITLE
Purger permissions and limit workaround

### DIFF
--- a/nerdlandbot/commands/purger.py
+++ b/nerdlandbot/commands/purger.py
@@ -44,7 +44,7 @@ class purger(commands.Cog, name="Purger_lists"):
 
         # member = ctx.get_member(ctx.user.id)
         channel_permissions = channel.permissions_for(ctx.me)
-        if not channel_permissions.manage_messages:
+        if not (channel_permissions.manage_messages and channel_permissions.read_message_history):
             return await ctx.send(translate("purger_permissions", await culture(ctx)))
 
         add_response = await guild_data.add_purger(channel, max_age)

--- a/nerdlandbot/scheduler/PurgeScheduler.py
+++ b/nerdlandbot/scheduler/PurgeScheduler.py
@@ -23,7 +23,9 @@ async def purge_messages(bot):
                 channel = bot.get_channel(int(text_channel))
                 try:
                     if channel:
-                        await channel.purge(check=check, before=before)
+                        deleted_messages = [1]
+                        while len(deleted_messages) > 0:
+                            deleted_messages = await channel.purge(check=check, before=before)
                 except:
                     fatal(
                         f"Failed to purge messages for channel {channel.name} in guild {guild_data.guild_id}. Does the bot have appropriate permissions on that channel?"

--- a/nerdlandbot/scheduler/PurgeScheduler.py
+++ b/nerdlandbot/scheduler/PurgeScheduler.py
@@ -23,9 +23,10 @@ async def purge_messages(bot):
                 channel = bot.get_channel(int(text_channel))
                 try:
                     if channel:
-                        deleted_messages = [1]
-                        while len(deleted_messages) > 0:
+                        while True:
                             deleted_messages = await channel.purge(check=check, before=before)
+                            if len(deleted_messages) == 0:
+                                break
                 except:
                     fatal(
                         f"Failed to purge messages for channel {channel.name} in guild {guild_data.guild_id}. Does the bot have appropriate permissions on that channel?"


### PR DESCRIPTION
Added a check for the read_message_history permissions when adding a purger.
Added a while loop to keep purging messages as long as not everything is purged.