### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
 # nerdlandbot
+
 This is a Python-based discord bot developed by the nerdland fan community.
 
 # Roadmap
+
 This bot was setup mostly as an experiment, and there is no clearly defined goal so far.
 If you have any suggestions feel free to log an issue in this repository, any new ideas or challenges are much appreciated.
 
 # Getting started
+
 To get this project up and running, make sure you have the following installed:
+
 - Python 3
 - PIP
 - [Poetry](https://python-poetry.org/docs/#installation)
 
-Once you have these installed (you can check by running 'python --version', 'pip -V' and 'poetry -V' in a commandline) run the following command to install the required packages:
+Once you have these installed (you can check by running 'python --version', 'pip -V' and 'poetry -V' in a commandline) run the following command with each package listed in `requirements.txt` to install the required packages:
+
 ```
-poetry install
+pip install <package name>
 ```
 
-You will also need to acquire a `DISCORD_TOKEN` for this to work. It is possible to obtain one with a developer account on Discord.
+You will also need to acquire a `DISCORD_TOKEN` for this to work. It is possible to obtain one with a developer account on Discord [here](https://discord.com/developers/applications).
 
 For using the YouTube notifications functionality you'll need to set the `YOUTUBE TOKEN` in your `.env` file. Follow the instructions [here](https://developers.google.com/youtube/registering_an_application) to create an API key.
 
+Finally you need to enable `PRESENCE INTENT` and `SERVER MEMBERS INTENT` in the Discord Developer Portal in your bot's setting.
+
 You can now run the bot by running the following command:
+
 ```
 python -m nerdlandbot
 ```
@@ -36,5 +44,6 @@ docker run -itd --restart="unless-stopped" --name nerdlandbot \
 ```
 
 # Links
-* [Nerdland website](https://nerdland.be)
-* [Nerdland merch](https://www.mistert.be/nerdland)
+
+- [Nerdland website](https://nerdland.be)
+- [Nerdland merch](https://www.mistert.be/nerdland)


### PR DESCRIPTION
Since 'poetry install' wasn't working (it only installed discord.py and not the other dependencies causing the bot not to work), I changed it to 'pip install' with a short explanation on how to use it.

Added a link to the discord developer portal where people need to go to get their `DISCORD_TOKEN`

Added instruction to enable the necessary intents in the bot's settings in discord developer portal.